### PR TITLE
A bunch of updates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ DistributionsAD = "ced4e74d-a319-5a8a-b0ac-84af2272839c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 CommonSolve = "0.2"

--- a/src/DifferenceEquations.jl
+++ b/src/DifferenceEquations.jl
@@ -4,6 +4,7 @@ using Distributions
 using DistributionsAD
 using LinearAlgebra
 using CommonSolve
+using Zygote
 
 import SciMLBase
 import SciMLBase: SciMLProblem, solve
@@ -15,16 +16,14 @@ abstract type AbstractStateSpaceProblem{isinplace} <: DifferenceProblem end
 # Wrapper struct, eventually needs to be a full cache
 struct StateSpaceCache{
     probtype<:AbstractStateSpaceProblem, 
-    solvertype<:SciMLBase.SciMLAlgorithm,
-    vectype
+    solvertype<:SciMLBase.SciMLAlgorithm
 }
     problem::probtype
     solver::solvertype
-    vtype::vectype
 end 
 
 function StateSpaceCache(problem::AbstractStateSpaceProblem, solver::SciMLBase.SciMLAlgorithm)
-    return StateSpaceCache(problem, solver, identity)
+    return StateSpaceCache(problem, solver)
 end
 
 # Unpack the cache. In future, this unwrapping should be eliminated when the cache

--- a/src/DifferenceEquations.jl
+++ b/src/DifferenceEquations.jl
@@ -33,7 +33,7 @@ function CommonSolve.solve!(
     args...; 
     kwargs...
 )
-    return _solve!(cache.problem, cache.solver, args...; vectype=cache.vtype, kwargs...)
+    return _solve!(cache.problem, cache.solver, args...; kwargs...)
 end
 
 # Yuck hate this so much

--- a/src/kalman.jl
+++ b/src/kalman.jl
@@ -2,7 +2,6 @@ function _solve!(
     prob::LinearStateSpaceProblem{isinplace, Atype, Btype, Ctype, wtype, Rtype, utype, ttype, otype},
     solver::KalmanFilter,
     args...;
-    vectype = identity,
     kwargs...
 ) where {isinplace, Atype, Btype, Ctype, wtype, Rtype<:Distribution, utype, ttype, otype}
     # Preallocate values
@@ -16,9 +15,9 @@ function _solve!(
     u0_mean = mean(prob.u0)
     u0_variance = cov(prob.u0)
 
-    u = vectype(Vector{typeof(u0_mean)}(undef, T)) # Mean of Kalman filter inferred latent states
-    P = vectype(Vector{Matrix{eltype(u0_mean)}}(undef, T)) # Posterior variance of Kalman filter inferred latent states
-    z = vectype(Vector{typeof(u0_mean)}(undef, T)) # Mean of observables, generated from mean of latent states
+    u = Zygote.buffer(Vector{typeof(u0_mean)}(undef, T)) # Mean of Kalman filter inferred latent states
+    P = Zygote.buffer(Vector{Matrix{eltype(u0_mean)}}(undef, T)) # Posterior variance of Kalman filter inferred latent states
+    z = Zygote.buffer(Vector{typeof(u0_mean)}(undef, T)) # Mean of observables, generated from mean of latent states
 
     u[1] = u0_mean
     P[1] = u0_variance

--- a/src/kalman.jl
+++ b/src/kalman.jl
@@ -15,9 +15,9 @@ function _solve!(
     u0_mean = mean(prob.u0)
     u0_variance = cov(prob.u0)
 
-    u = Zygote.buffer(Vector{typeof(u0_mean)}(undef, T)) # Mean of Kalman filter inferred latent states
-    P = Zygote.buffer(Vector{Matrix{eltype(u0_mean)}}(undef, T)) # Posterior variance of Kalman filter inferred latent states
-    z = Zygote.buffer(Vector{typeof(u0_mean)}(undef, T)) # Mean of observables, generated from mean of latent states
+    u = Zygote.Buffer(Vector{typeof(u0_mean)}(undef, T)) # Mean of Kalman filter inferred latent states
+    P = Zygote.Buffer(Vector{Matrix{eltype(u0_mean)}}(undef, T)) # Posterior variance of Kalman filter inferred latent states
+    z = Zygote.Buffer(Vector{typeof(u0_mean)}(undef, T)) # Mean of observables, generated from mean of latent states
 
     u[1] = u0_mean
     P[1] = u0_variance

--- a/src/linear.jl
+++ b/src/linear.jl
@@ -92,8 +92,10 @@ function _solve!(
     A, B, C = prob.A, prob.B, prob.C
 
     u = Zygote.Buffer(Vector{utype}(undef, T)) # Latent states
-    n = Zygote.Buffer(Vector{utype}(undef, T)) # Latent noise
-    z = Zygote.Buffer(Vector{utype}(undef, T)) # Observables generated
+    n1 = prob.noise[1]
+    n = Zygote.Buffer(Vector{typeof(n1)}(undef, T)) # Latent noise
+    z1 = C * prob.u0
+    z = Zygote.Buffer(Vector{typeof(z1)}(undef, T)) # Observables generated
 
     # Initialize
     u[1] = prob.u0
@@ -120,8 +122,10 @@ function _solve!(
     A, B, C = prob.A, prob.B, prob.C
 
     u = Zygote.Buffer(Vector{utype}(undef, T)) # Latent states
-    n = Zygote.Buffer(Vector{utype}(undef, T)) # Latent noise
-    z = Zygote.Buffer(Vector{utype}(undef, T)) # Observables generated
+    n1 = prob.noise[1]
+    n = Zygote.Buffer(Vector{typeof(n1)}(undef, T)) # Latent noise
+    z1 = C * prob.u0
+    z = Zygote.Buffer(Vector{typeof(z1)}(undef, T)) # Observables generated
 
     # Initialize
     u[1] = prob.u0

--- a/src/linear.jl
+++ b/src/linear.jl
@@ -32,7 +32,7 @@ function LinearStateSpaceProblem(
     tspan::ttype;
     obs_noise = (h0 = C * u0; MvNormal(zeros(eltype(h0), length(h0)), I)), # Assume the default measurement error is MvNormal with identity covariance
     observables = nothing,
-    noise,
+    noise = nothing,
 ) where {
     Atype<:AbstractArray, 
     Btype<:AbstractArray, 
@@ -91,9 +91,9 @@ function _solve!(
     T = prob.tspan[2] - prob.tspan[1] + 1
     A, B, C = prob.A, prob.B, prob.C
 
-    u = Zygote.buffer(Vector{utype}(undef, T)) # Latent states
-    n = Zygote.buffer(Vector{utype}(undef, T)) # Latent noise
-    z = Zygote.buffer(Vector{utype}(undef, T)) # Observables generated
+    u = Zygote.Buffer(Vector{utype}(undef, T)) # Latent states
+    n = Zygote.Buffer(Vector{utype}(undef, T)) # Latent noise
+    z = Zygote.Buffer(Vector{utype}(undef, T)) # Observables generated
 
     # Initialize
     u[1] = prob.u0
@@ -119,9 +119,9 @@ function _solve!(
     T = prob.tspan[2] - prob.tspan[1] + 1
     A, B, C = prob.A, prob.B, prob.C
 
-    u = Zygote.buffer(Vector{utype}(undef, T)) # Latent states
-    n = Zygote.buffer(Vector{utype}(undef, T)) # Latent noise
-    z = Zygote.buffer(Vector{utype}(undef, T)) # Observables generated
+    u = Zygote.Buffer(Vector{utype}(undef, T)) # Latent states
+    n = Zygote.Buffer(Vector{utype}(undef, T)) # Latent noise
+    z = Zygote.Buffer(Vector{utype}(undef, T)) # Observables generated
 
     # Initialize
     u[1] = prob.u0

--- a/src/nonlinear.jl
+++ b/src/nonlinear.jl
@@ -13,7 +13,7 @@ struct StateSpaceProblem{
     f::ftype # Evolution function
     g::gtype # Noise function
     h::htype # Observation function
-    noise::wtype # Latent noise distribution
+    noise::wtype # Latent noises
     obs_noise::vtype # Observation noise / measurement error distribution
     u0::utype # Initial condition
     tspan::ttype # Timespan to use
@@ -30,7 +30,7 @@ function StateSpaceProblem(
     params = nothing;
     obs_noise = (h0 = h(u0, params, tspan[1]); MvNormal(zeros(eltype(h0), length(h0)), I)), # Assume the default measurement error is MvNormal with identity covariance
     observables = nothing,
-    noise = StandardGaussian(size(u0)),
+    noise,
 ) where {
     ftype, 
     gtype, 
@@ -54,7 +54,7 @@ function StateSpaceProblem(
         f, # Evolution function
         g, # Noise function
         h, # Observation function
-        noise, # Latent noise matrix/function/distribution
+        noise, # Latent noises
         obs_noise, # Observation noise distribution
         u0, # Initial condition
         tspan, # Timespan to use
@@ -91,7 +91,7 @@ function _solve!(
     T = prob.tspan[2] - prob.tspan[1] + 1
 
     u = Zygote.buffer(Vector{utype}(undef, T)) # Latent states
-    n1 = noise(prob.noise, 1) # This is only to grab the type of the noises
+    n1 = prob.noise[1] # This is only to grab the type of the noises. We won't use it in the simulation
     n = Zygote.buffer(Vector{typeof(n1)}(undef, T)) # Latent noise
     z1 = prob.h(prob.u0, prob.params, prob.tspan[1]) # Grab the type of the observations of the initial latent states
     z = Zygote.buffer(Vector{typeof(z1)}(undef, T)) # Observables generated
@@ -102,7 +102,7 @@ function _solve!(
 
     for t in 2:T
         t_n = t - 1 + prob.tspan[1]
-        n[t] = noise(prob.noise, t_n)
+        n[t] = prob.noise[t_n]
         u[t] = prob.f(u[t - 1], prob.params, t_n - 1) .+ prob.g(u[t - 1], prob.params, t_n - 1) * n[t]
         z[t] = prob.h(u[t], prob.params, t_n)
     end
@@ -120,7 +120,7 @@ function _solve!(
     T = prob.tspan[2] - prob.tspan[1] + 1
 
     u = Zygote.buffer(Vector{utype}(undef, T)) # Latent states
-    n1 = noise(prob.noise, 1) # This is only to grab the type of the noises
+    n1 = prob.noise[1] # This is only to grab the type of the noises. We won't use it in the simulation
     n = Zygote.buffer(Vector{typeof(n1)}(undef, T)) # Latent noise
     z1 = prob.h(prob.u0, prob.params, prob.tspan[1]) # Grab the type of the observations of the initial latent states
     z = Zygote.buffer(Vector{typeof(z1)}(undef, T)) # Observables generated
@@ -132,11 +132,11 @@ function _solve!(
     loglik = 0.0
     for t in 2:T
         t_n = t - 1 + prob.tspan[1]
-        n[t] = noise(prob.noise, t_n)
+        n[t] = prob.noise[t_n]
         u[t] = prob.f(u[t - 1], prob.params, t_n - 1) .+ prob.g(u[t - 1], prob.params, t_n - 1) * n[t]
         z[t] = prob.h(u[t], prob.params, t_n)
         # Likelihood accumulation when data observations are provided
-        loglik += logpdf(prob.obs_noise, z[t] - prob.observables[t_n])
+        loglik += logpdf(prob.obs_noise, prob.observables[t_n] - z[t])
     end
 
     return StateSpaceSolution(nothing, nothing, nothing, nothing, loglik)

--- a/src/nonlinear.jl
+++ b/src/nonlinear.jl
@@ -30,7 +30,7 @@ function StateSpaceProblem(
     params = nothing;
     obs_noise = (h0 = h(u0, params, tspan[1]); MvNormal(zeros(eltype(h0), length(h0)), I)), # Assume the default measurement error is MvNormal with identity covariance
     observables = nothing,
-    noise,
+    noise = nothing,
 ) where {
     ftype, 
     gtype, 
@@ -90,11 +90,11 @@ function _solve!(
     # Preallocate values
     T = prob.tspan[2] - prob.tspan[1] + 1
 
-    u = Zygote.buffer(Vector{utype}(undef, T)) # Latent states
+    u = Zygote.Buffer(Vector{utype}(undef, T)) # Latent states
     n1 = prob.noise[1] # This is only to grab the type of the noises. We won't use it in the simulation
-    n = Zygote.buffer(Vector{typeof(n1)}(undef, T)) # Latent noise
+    n = Zygote.Buffer(Vector{typeof(n1)}(undef, T)) # Latent noise
     z1 = prob.h(prob.u0, prob.params, prob.tspan[1]) # Grab the type of the observations of the initial latent states
-    z = Zygote.buffer(Vector{typeof(z1)}(undef, T)) # Observables generated
+    z = Zygote.Buffer(Vector{typeof(z1)}(undef, T)) # Observables generated
 
     # Initialize
     u[1] = prob.u0
@@ -119,11 +119,11 @@ function _solve!(
     # Preallocate values
     T = prob.tspan[2] - prob.tspan[1] + 1
 
-    u = Zygote.buffer(Vector{utype}(undef, T)) # Latent states
+    u = Zygote.Buffer(Vector{utype}(undef, T)) # Latent states
     n1 = prob.noise[1] # This is only to grab the type of the noises. We won't use it in the simulation
-    n = Zygote.buffer(Vector{typeof(n1)}(undef, T)) # Latent noise
+    n = Zygote.Buffer(Vector{typeof(n1)}(undef, T)) # Latent noise
     z1 = prob.h(prob.u0, prob.params, prob.tspan[1]) # Grab the type of the observations of the initial latent states
-    z = Zygote.buffer(Vector{typeof(z1)}(undef, T)) # Observables generated
+    z = Zygote.Buffer(Vector{typeof(z1)}(undef, T)) # Observables generated
 
     # Initialize
     u[1] = prob.u0

--- a/test/dssm.jl
+++ b/test/dssm.jl
@@ -30,14 +30,14 @@ problem = StateSpaceProblem(
     u0,
     (0, T),
     sol,
-    noise = StandardGaussian(1)
+    noise = [randn(sol.n_ϵ) for _ in 1:T]
 )
 
 # Solve the model, this generates
 # simulated data.
 simul = @inferred DifferenceEquations.solve(problem, NoiseConditionalFilter())
-# Grab simulated data for the next tests
-z = simul.z
+# Grab simulated data for the next tests, leave the first one -- the initial condition -- out
+z = simul.z[2:end]
 
 # Now solve using the previous data as observables.
 # Solving this problem also includes a likelihood.
@@ -50,7 +50,7 @@ problem_data = StateSpaceProblem(
     sol,
     obs_noise = sol.D,
     observables = z,
-    noise = StandardGaussian(1)
+    noise = [randn(sol.n_ϵ) for _ in 1:T]
 )
 
 # Generate likelihood.

--- a/test/dssm.jl
+++ b/test/dssm.jl
@@ -87,6 +87,6 @@ end
         observables = z
     )
 
-    # Solve with Kalman filter
+    # Simulate linear AR(1) process
     simul_linear = @inferred DifferenceEquations.solve(linear_problem, NoiseConditionalFilter())
 end


### PR DESCRIPTION
This PR fixes the previous issues in ~~`linear.jl`~~ all the files,
1. Timing should be consistent with Kalman and nonlinear ones
2. Fix the type of the returned object
3. Make obs_noise a distribution (consistent with Kalman and nonlinear ones)
4. Add related tests
5. Remove `vectype` and include `Zygote.buffer` directly