### PR TITLE
Fix SciMLBase v3 breaking changes and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DifferenceEquations"
 uuid = "e0ca9c66-1f9e-11ec-127a-1304ce62169c"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["various contributors"]
 
 [deps]
@@ -24,6 +24,6 @@ LinearAlgebra = "1"
 PDMats = "0.11"
 PrecompileTools = "1"
 RecursiveArrayTools = "2.34"
-SciMLBase = "1.90, 2"
+SciMLBase = "2, 3"
 UnPack = "1"
 julia = "1.8"

--- a/src/DifferenceEquations.jl
+++ b/src/DifferenceEquations.jl
@@ -2,7 +2,7 @@ module DifferenceEquations
 
 using ChainRulesCore: ChainRulesCore, NoTangent, Tangent, ZeroTangent
 using CommonSolve: CommonSolve, solve
-using DiffEqBase: DiffEqBase, DEProblem, get_concrete_u0, get_concrete_p, isconcreteu0,
+using DiffEqBase: DiffEqBase, AbstractDEProblem, get_concrete_u0, get_concrete_p, isconcreteu0,
     promote_u0
 using Distributions: Distributions, Distribution, MvNormal, UnivariateDistribution,
     ZeroMeanDiagNormal, logpdf

--- a/src/problems/state_space_problems.jl
+++ b/src/problems/state_space_problems.jl
@@ -1,4 +1,4 @@
-abstract type AbstractStateSpaceProblem <: DEProblem end
+abstract type AbstractStateSpaceProblem <: AbstractDEProblem end
 abstract type AbstractPerturbationProblem <: AbstractStateSpaceProblem end
 
 # TODO: Can add in more checks on the algorithm choice

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,6 +1,6 @@
-using DiffEqBase: DEAlgorithm, KeywordArgSilent
+using DiffEqBase: AbstractDEAlgorithm, KeywordArgSilent
 
-abstract type AbstractDifferenceEquationAlgorithm <: DEAlgorithm end
+abstract type AbstractDifferenceEquationAlgorithm <: AbstractDEAlgorithm end
 struct DirectIteration <: AbstractDifferenceEquationAlgorithm end
 struct KalmanFilter <: AbstractDifferenceEquationAlgorithm end
 


### PR DESCRIPTION
## Summary

- Replace removed `DiffEqBase.DEAlgorithm` with `DiffEqBase.AbstractDEAlgorithm` in `src/solve.jl`
- Replace removed `DiffEqBase.DEProblem` with `DiffEqBase.AbstractDEProblem` in `src/DifferenceEquations.jl` and `src/problems/state_space_problems.jl`
- Update SciMLBase compat bounds from `"1.90, 2"` to `"2, 3"`
- Bump package version from 1.0.0 to 1.1.0
- Supersedes #153

## Details

SciMLBase v3 removed the type aliases `DEAlgorithm` and `DEProblem` (which were non-`Abstract` aliases). The replacements are the canonical abstract types `AbstractDEAlgorithm` and `AbstractDEProblem` which have been available since SciMLBase v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)