### PR TITLE
Widen DiffEqBase compat to allow v7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 [compat]
 ChainRulesCore = "1.24"
 CommonSolve = "0.2"
-DiffEqBase = "6.145"
+DiffEqBase = "6.145, 7"
 Distributions = "0.25"
 LinearAlgebra = "1"
 PDMats = "0.11"


### PR DESCRIPTION
## Summary

- Widens `DiffEqBase` compat from `"6.145"` to `"6.145, 7"` to support the v7 ecosystem
- All DiffEqBase APIs used in this package (`AbstractDEAlgorithm`, `KeywordArgSilent`, `check_prob_alg_pairing`, `get_concrete_problem`, `get_concrete_u0`, `get_concrete_p`, `isconcreteu0`, `promote_u0`, `AbstractDEProblem`) are present and unchanged in DiffEqBase v7
- No source or test changes required — purely a compat bump
- `RecursiveArrayTools` and `SciMLBase` were already widened to v4/v3 respectively

## Test plan

- [ ] CI passes with DiffEqBase v7 resolved
- [ ] `Pkg.resolve()` selects DiffEqBase v7.0.0 with the updated compat

🤖 Generated with [Claude Code](https://claude.com/claude-code)