### PR TITLE
Bump version to 1.1.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DifferenceEquations"
 uuid = "e0ca9c66-1f9e-11ec-127a-1304ce62169c"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["various contributors"]
 
 [workspace]


### PR DESCRIPTION
Automated patch version bump (1.1.0 -> 1.1.1) to release unreleased commits on `main` via JuliaRegistrator.