### PR TITLE
Use SciMLTesting public API docs QA

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -17,9 +17,6 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-DifferenceEquations = {path = ".."}
-
 [compat]
 DataFrames = "1.8.2"
 DelimitedFiles = "1.9.1"
@@ -32,5 +29,5 @@ FiniteDifferences = "0.12.34"
 ForwardDiff = "1.4.0"
 Plots = "1.41.6"
 SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "1.2"
+SciMLTesting = "2.1"
 StaticArrays = "1.9.8"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -6,9 +6,6 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-DifferenceEquations = {path = "../.."}
-
 [compat]
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -12,6 +12,6 @@ DifferenceEquations = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
-SciMLTesting = "1.7"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -46,6 +46,10 @@ run_qa(
             ),
         ),
     ),
+    api_docs_kwargs = (;
+        rendered = true,
+        rendered_ignore = (:remake, :solve),
+    ),
 )
 
 # JET cases tied to issue #187 are bespoke `report_call`s on specific solve paths:


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary
- update test/qa SciMLTesting compat to exactly 2.1
- use SciMLTesting public API docs QA with rendered docs coverage
- ignore rendered-docs coverage for re-exported solve/remake

## Checks
- `timeout 3600 ~/.juliaup/bin/julia +1.10 --startup-file=no --project=test/qa -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("test/qa/qa.jl")'`\n- `timeout 3600 julia --startup-file=no -m Runic --check test/qa/qa.jl`\n- TOML parse for `test/qa/Project.toml`\n- grep for `api_docs = false`, `docstrings_broken`, `Base.Docs`, `missing_docstrings`