### PR TITLE
Avoid BLAS paths in Enzyme-sensitive helpers

### DIFF
--- a/src/DifferenceEquations.jl
+++ b/src/DifferenceEquations.jl
@@ -3,8 +3,8 @@ module DifferenceEquations
 using CommonSolve: CommonSolve, solve, init, solve!
 using ConcreteStructs: @concrete
 using DiffEqBase: DiffEqBase, get_concrete_u0, get_concrete_p, isconcreteu0, promote_u0
-using LinearAlgebra: LinearAlgebra, Diagonal, NoPivot, Symmetric, cholesky,
-    cholesky!, dot, ldiv!, mul!, transpose!
+using LinearAlgebra: LinearAlgebra, Diagonal, Symmetric, cholesky,
+    dot, ldiv!, mul!, transpose!
 using SciMLBase: SciMLBase, @add_kwonly, NullParameters, promote_tspan, AbstractDEProblem,
     AbstractRODESolution, ODEFunction, remake, ConstantInterpolation, build_solution, ReturnCode
 using StaticArrays: StaticArrays, SVector, SMatrix, StaticMatrix, ismutable

--- a/src/algorithms/linear.jl
+++ b/src/algorithms/linear.jl
@@ -148,7 +148,7 @@ function _solve_direct_iteration!(
             ν_solved = cache.innovation_solved[t - 1]
             ν_solved = ldiv!!(ν_solved, F_obs, ν)
             cache.innovation_solved[t - 1] = ν_solved
-            quad = dot(ν, ν_solved)
+            quad = dot_no_blas(ν, ν_solved)
             loglik -= 0.5 * (log_const + quad)
         end
     end
@@ -248,7 +248,7 @@ function _solve_direct_iteration_endpoints!(
             ν_solved = cache.innovation_solved[1]
             ν_solved = ldiv!!(ν_solved, F_obs, ν)
             cache.innovation_solved[1] = ν_solved
-            quad = dot(ν, ν_solved)
+            quad = dot_no_blas(ν, ν_solved)
             loglik -= 0.5 * (log_const + quad)
         end
     end
@@ -383,7 +383,7 @@ function _solve_conditional_likelihood!(
         ν_solved = cache.innovation_solved[t - 1]
         ν_solved = ldiv!!(ν_solved, F_obs, ν)
         cache.innovation_solved[t - 1] = ν_solved
-        quad = dot(ν, ν_solved)
+        quad = dot_no_blas(ν, ν_solved)
         loglik -= 0.5 * (log_const + quad)
 
         # CLAMP: set state to observation for next step
@@ -473,7 +473,7 @@ function _solve_conditional_likelihood_endpoints!(
         ν_solved = cache.innovation_solved[1]
         ν_solved = ldiv!!(ν_solved, F_obs, ν)
         cache.innovation_solved[1] = ν_solved
-        quad = dot(ν, ν_solved)
+        quad = dot_no_blas(ν, ν_solved)
         loglik -= 0.5 * (log_const + quad)
 
         # CLAMP
@@ -639,7 +639,7 @@ function _solve!(
         cache.innovation[t] = ν
         cache.innovation_solved[t] = ν_solved
         logdetS = logdet_chol(F)
-        quad = dot(ν_solved, ν)
+        quad = dot_no_blas(ν_solved, ν)
         loglik -= 0.5 * (log_const_kf + logdetS + quad)
     end
 
@@ -774,7 +774,7 @@ function _solve_kalman_endpoints!(
         cache.innovation[1] = ν
         cache.innovation_solved[1] = ν_solved
         logdetS = logdet_chol(F)
-        quad = dot(ν_solved, ν)
+        quad = dot_no_blas(ν_solved, ν)
         loglik -= 0.5 * (log_const_kf + logdetS + quad)
     end
 

--- a/src/utilities_bangbang.jl
+++ b/src/utilities_bangbang.jl
@@ -5,7 +5,7 @@
     mul!!(Y, A, B)
 
 Computes `Y = A * B`.
-- If `Y` is mutable (e.g., Vector), it mutates `Y` in-place using `mul!`.
+- If `Y` is mutable (e.g., Vector), it mutates `Y` in-place.
 - If `Y` is immutable (e.g., SVector), it returns a new result.
 """
 @inline function mul!!(Y, A, B)
@@ -17,11 +17,20 @@ Computes `Y = A * B`.
     end
 end
 
+@inline function mul!!(Y::AbstractVector, A::AbstractMatrix, B::AbstractVector)
+    if ismutable(Y)
+        matvec_no_blas!(Y, A, B)
+        return Y
+    else
+        return A * B
+    end
+end
+
 """
     mul!!(Y, A, B, α, β)
 
 Computes `Y = α * A * B + β * Y` (5-argument form).
-- If `Y` is mutable, it mutates `Y` in-place using `mul!(Y, A, B, α, β)`.
+- If `Y` is mutable, it mutates `Y` in-place.
 - If `Y` is immutable, it returns `α * (A * B) + β * Y`.
 """
 @inline function mul!!(Y, A, B, α, β)
@@ -33,11 +42,20 @@ Computes `Y = α * A * B + β * Y` (5-argument form).
     end
 end
 
+@inline function mul!!(Y::AbstractVector, A::AbstractMatrix, B::AbstractVector, α, β)
+    if ismutable(Y)
+        matvec_no_blas!(Y, A, B, α, β)
+        return Y
+    else
+        return α * (A * B) + β * Y
+    end
+end
+
 """
     muladd!!(Y, A, B)
 
 Computes `Y = Y + A * B`.
-- If `Y` is mutable (e.g., Vector), it mutates `Y` in-place using `mul!`.
+- If `Y` is mutable (e.g., Vector), it mutates `Y` in-place.
 - If `Y` is immutable (e.g., SVector), it returns a new generic result.
 - If `A` or `B` is `nothing`, returns `Y` unchanged (no-op).
 """
@@ -50,10 +68,61 @@ Computes `Y = Y + A * B`.
     end
 end
 
+@inline function muladd!!(Y::AbstractVector, A::AbstractMatrix, B::AbstractVector)
+    if ismutable(Y)
+        T = promote_type(eltype(Y), eltype(A), eltype(B))
+        matvec_no_blas!(Y, A, B, one(T), one(T))
+        return Y
+    else
+        return Y + A * B
+    end
+end
+
 # Specializations for nothing arguments (no-op)
 @inline muladd!!(Y, ::Nothing, B) = Y
 @inline muladd!!(Y, A, ::Nothing) = Y
 @inline muladd!!(Y, ::Nothing, ::Nothing) = Y
+
+@inline function matvec_no_blas!(Y, A, B)
+    @boundscheck begin
+        size(Y, 1) == size(A, 1) && size(A, 2) == size(B, 1) ||
+            throw(DimensionMismatch("matrix-vector dimensions must match"))
+    end
+    @inbounds for i in axes(A, 1)
+        acc = zero(promote_type(eltype(A), eltype(B)))
+        for j in axes(A, 2)
+            acc += A[i, j] * B[j]
+        end
+        Y[i] = acc
+    end
+    return Y
+end
+
+@inline function matvec_no_blas!(Y, A, B, α, β)
+    @boundscheck begin
+        size(Y, 1) == size(A, 1) && size(A, 2) == size(B, 1) ||
+            throw(DimensionMismatch("matrix-vector dimensions must match"))
+    end
+    @inbounds for i in axes(A, 1)
+        acc = zero(promote_type(eltype(A), eltype(B)))
+        for j in axes(A, 2)
+            acc += A[i, j] * B[j]
+        end
+        Y[i] = α * acc + β * Y[i]
+    end
+    return Y
+end
+
+@inline function dot_no_blas(x::AbstractVector, y::AbstractVector)
+    @boundscheck begin
+        size(x, 1) == size(y, 1) || throw(DimensionMismatch("vector dimensions must match"))
+    end
+    acc = zero(promote_type(eltype(x), eltype(y)))
+    @inbounds for i in eachindex(x, y)
+        acc += conj(x[i]) * y[i]
+    end
+    return acc
+end
 
 """
     ldiv!!(y, F, x)
@@ -71,6 +140,24 @@ Computes `y = F \\ x` (linear solve with factorization F).
     end
 end
 
+@inline function ldiv!!(y::AbstractVector, F::LinearAlgebra.Cholesky, x::AbstractVector)
+    if ismutable(y)
+        cholesky_solve_no_blas!(y, F, x)
+        return y
+    else
+        return F \ x
+    end
+end
+
+@inline function ldiv!!(Y::AbstractMatrix, F::LinearAlgebra.Cholesky, X::AbstractMatrix)
+    if ismutable(Y)
+        cholesky_solve_no_blas!(Y, F, X)
+        return Y
+    else
+        return F \ X
+    end
+end
+
 """
     ldiv!!(F, x)
 
@@ -84,6 +171,24 @@ Computes `x = F \\ x` in-place (2-argument form).
         return x
     else
         return F \ x
+    end
+end
+
+@inline function ldiv!!(F::LinearAlgebra.Cholesky, x::AbstractVector)
+    if ismutable(x)
+        cholesky_solve_no_blas!(x, F, x)
+        return x
+    else
+        return F \ x
+    end
+end
+
+@inline function ldiv!!(F::LinearAlgebra.Cholesky, X::AbstractMatrix)
+    if ismutable(X)
+        cholesky_solve_no_blas!(X, F, X)
+        return X
+    else
+        return F \ X
     end
 end
 
@@ -125,15 +230,130 @@ end
     cholesky!!(A, uplo::Symbol=:U)
 
 Computes Cholesky factorization of symmetric matrix A.
-- If `A` is mutable, uses `cholesky!(Symmetric(A, uplo), NoPivot(); check=false)`.
+- If `A` is mutable, factors `A` in-place and returns a `Cholesky` factorization.
 - If `A` is immutable, uses `cholesky(Symmetric(A, uplo))`.
 """
 @inline function cholesky!!(A, uplo::Symbol = :U)
     if ismutable(A)
-        return cholesky!(Symmetric(A, uplo), NoPivot(); check = false)
+        cholesky_no_lapack!(A, uplo)
+        return LinearAlgebra.Cholesky(A, uplo, 0)
     else
         return cholesky(Symmetric(A, uplo))
     end
+end
+
+@inline function cholesky_no_lapack!(A, uplo::Symbol)
+    @boundscheck begin
+        size(A, 1) == size(A, 2) || throw(DimensionMismatch("matrix must be square"))
+    end
+    if uplo === :U
+        return cholesky_upper_no_lapack!(A)
+    elseif uplo === :L
+        return cholesky_lower_no_lapack!(A)
+    else
+        throw(ArgumentError("uplo must be :U or :L"))
+    end
+end
+
+@inline function cholesky_upper_no_lapack!(A)
+    n = size(A, 1)
+    @inbounds for j in 1:n
+        for k in 1:(j - 1)
+            acc = A[k, j]
+            for i in 1:(k - 1)
+                acc -= A[i, k] * A[i, j]
+            end
+            A[k, j] = acc / A[k, k]
+        end
+        diag = A[j, j]
+        for i in 1:(j - 1)
+            diag -= A[i, j] * A[i, j]
+        end
+        real(diag) > 0 || throw(LinearAlgebra.PosDefException(j))
+        A[j, j] = sqrt(diag)
+    end
+    @inbounds for j in 1:n
+        for i in (j + 1):n
+            A[i, j] = zero(eltype(A))
+        end
+    end
+    return A
+end
+
+@inline function cholesky_lower_no_lapack!(A)
+    n = size(A, 1)
+    @inbounds for j in 1:n
+        for k in 1:(j - 1)
+            acc = A[j, k]
+            for i in 1:(k - 1)
+                acc -= A[k, i] * A[j, i]
+            end
+            A[j, k] = acc / A[k, k]
+        end
+        diag = A[j, j]
+        for i in 1:(j - 1)
+            diag -= A[j, i] * A[j, i]
+        end
+        real(diag) > 0 || throw(LinearAlgebra.PosDefException(j))
+        A[j, j] = sqrt(diag)
+    end
+    @inbounds for j in 1:n
+        for i in 1:(j - 1)
+            A[i, j] = zero(eltype(A))
+        end
+    end
+    return A
+end
+
+@inline function cholesky_solve_no_blas!(y::AbstractVector, F::LinearAlgebra.Cholesky, x::AbstractVector)
+    U = F.U
+    n = size(U, 1)
+    @boundscheck begin
+        size(y, 1) == size(x, 1) || throw(DimensionMismatch("right-hand side dimensions must match"))
+        size(x, 1) == n ||
+            throw(DimensionMismatch("factor and right-hand side dimensions must match"))
+    end
+    @inbounds for i in 1:n
+        y[i] = x[i]
+    end
+    cholesky_solve_vector_no_blas!(y, U)
+    return y
+end
+
+@inline function cholesky_solve_no_blas!(Y::AbstractMatrix, F::LinearAlgebra.Cholesky, X::AbstractMatrix)
+    U = F.U
+    n = size(U, 1)
+    @boundscheck begin
+        size(Y) == size(X) || throw(DimensionMismatch("right-hand side dimensions must match"))
+        size(X, 1) == n ||
+            throw(DimensionMismatch("factor and right-hand side dimensions must match"))
+    end
+    @inbounds for j in axes(X, 2)
+        for i in 1:n
+            Y[i, j] = X[i, j]
+        end
+        cholesky_solve_vector_no_blas!(view(Y, :, j), U)
+    end
+    return Y
+end
+
+@inline function cholesky_solve_vector_no_blas!(y, U)
+    n = size(U, 1)
+    @inbounds for i in 1:n
+        acc = y[i]
+        for k in 1:(i - 1)
+            acc -= U[k, i] * y[k]
+        end
+        y[i] = acc / U[i, i]
+    end
+    @inbounds for i in n:-1:1
+        acc = y[i]
+        for k in (i + 1):n
+            acc -= U[i, k] * y[k]
+        end
+        y[i] = acc / U[i, i]
+    end
+    return y
 end
 
 """

--- a/test/sensitivity_interface.jl
+++ b/test/sensitivity_interface.jl
@@ -29,6 +29,19 @@ function zero_minimal_cache!(cache)
     return cache
 end
 
+function minimal_matvec!(y, A, x)
+    size(y, 1) == size(A, 1) && size(A, 2) == size(x, 1) ||
+        throw(DimensionMismatch("matrix-vector dimensions must match"))
+    @inbounds for i in axes(A, 1)
+        acc = zero(promote_type(eltype(A), eltype(x)))
+        for j in axes(A, 2)
+            acc += A[i, j] * x[j]
+        end
+        y[i] = acc
+    end
+    return y
+end
+
 # =============================================================================
 # Solve: u[t+1] = A * u[t], in-place mutation of cache
 # =============================================================================
@@ -36,7 +49,7 @@ end
 function minimal_solve!(prob::MinimalProblem, cache::MinimalCache)
     cache.u[1] .= prob.u0
     for t in 1:(length(cache.u) - 1)
-        mul!(cache.u[t + 1], prob.A, cache.u[t])
+        minimal_matvec!(cache.u[t + 1], prob.A, cache.u[t])
     end
     return nothing
 end


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- Add explicit-loop mutable matrix-vector, dot, Cholesky, and Cholesky-solve helper paths used by the linear solvers.
- Update the minimal sensitivity MWE to avoid `mul!`, keeping the same in-place cache mutation behavior without hitting Julia 1.13 BLAS lazy loading under Enzyme.
- Keep the existing StaticArrays/immutable paths on the standard `*`/`cholesky` behavior.

## Root Cause
On Julia 1.13.0-rc1 with Enzyme 0.13.181, Enzyme fails when differentiating through stdlib BLAS/LAPACK paths such as `gemv!`, `dot`, and `potrf!`, with the first clean-main failures surfacing as `ijl_lazy_load_and_lookup`/LLVM verification errors. Julia 1.12.6 passed the same reported targets at commit `93ef77f`.

## Validation
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.13 --project=test --startup-file=no -e 'include("test/sensitivity_interface.jl")'` passed: 3 sanity, 12 forward, 24 reverse.\n- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.13 --project=test --startup-file=no -e 'include("test/gradient_comparison.jl")'` passed: 9 Kalman, 9 DI.\n- `CI=true timeout 3600 /home/crackauc/.juliaup/bin/julia +1.13 --project=. --startup-file=no -e 'using Pkg; Pkg.test()'` passed.\n- Runic.jl v1.7.0 `--check` passed on touched files.\n\n## Known Follow-up\nA non-CI local `Pkg.test()` run still fails later in the local-only `linear_direct_iteration_enzyme.jl` reverse DirectIteration loglik tests with `UndefRefError` around nested vector noise tangents. That is separate from the reported BLAS/LAPACK Julia 1.13 failures fixed here and should be investigated independently.