### PR TITLE
Release prep: bump version to 1.1.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DifferenceEquations"
 uuid = "e0ca9c66-1f9e-11ec-127a-1304ce62169c"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["various contributors"]
 
 [workspace]


### PR DESCRIPTION
## Summary

Bumps the package version from 1.1.1 to 1.1.2 to register the two commits merged since the last release (#192, which bumped to 1.1.1):

- #193 "Use SciMLTesting public API docs QA" — switches `test/Project.toml` and `test/qa/Project.toml` to use the SciMLTesting public API for QA/docs checks (compat pin update only, no source changes).
- #195 "Run Enzyme AD tests as a folder-discovered group excluded from prerelease Julia" — reorganizes the AD test suite into a dedicated `ad_group` (folder move + `test/test_groups.toml` entry) so Enzyme reverse-mode/gradient tests actually run in CI on released Julia versions; purely a test-infrastructure change.

## Bump type: PATCH (1.1.1 → 1.1.2)

Verified via `git diff 93ef77f..HEAD` (93ef77f = the 1.1.1 bump commit, tree matches the registry's recorded `git-tree-sha1` for 1.1.1) that there are **no changes** to `src/`, `Project.toml` deps/compat, `docs/`, or `.github/` — only `test/` files were touched (test reorganization + QA harness config). No new public API, no behavior change, no compat bound changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)