### PR TITLE
Fix downgrade workflow trigger for main

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -7,7 +7,7 @@ on:
       - 'docs/**'
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
 jobs:


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Point the downgrade workflow's push trigger at the repository's actual default branch, `main`, instead of the retired `master` name.

The pull-request trigger already used `main`; only pushes to the default branch were silently missing downgrade coverage.

## Local verification

- Reproduced the deployed downgrade workflow locally at commit `c77bb611` using Julia 1.10.11 and `julia-downgrade-compat` `fab1def`: 628/628 assertions passed.
- `Pkg.build()` passed in the exact floor environment.
- `actionlint .github/workflows/Downgrade.yml` passed.
- Runic 1.7 passed for all 51 Julia files.
- `git diff --check` passed.
