### PR TITLE
Use default rendered API docs QA

### DIFF
--- a/docs/src/basics/solvers.md
+++ b/docs/src/basics/solvers.md
@@ -3,8 +3,7 @@
 Solving a state-space problem is as simple as calling `solve(prob)`, which automatically selects an appropriate algorithm. You can also pass an algorithm explicitly via `solve(prob, alg)`.
 
 ```@docs
-solve
-remake
+solve(::AbstractStateSpaceProblem)
 DirectIteration
 ```
 

--- a/docs/src/basics/solvers.md
+++ b/docs/src/basics/solvers.md
@@ -3,6 +3,8 @@
 Solving a state-space problem is as simple as calling `solve(prob)`, which automatically selects an appropriate algorithm. You can also pass an algorithm explicitly via `solve(prob, alg)`.
 
 ```@docs
+solve
+remake
 DirectIteration
 ```
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -93,7 +93,40 @@ function default_alg(
     return KalmanFilter()
 end
 
-# Select default algorithm if not provided
+"""
+    solve(prob::AbstractStateSpaceProblem; kwargs...)
+
+Solve a state-space problem using its automatically selected algorithm.
+
+For a [`LinearStateSpaceProblem`](@ref), this selects [`KalmanFilter`](@ref) when the
+problem provides a Gaussian initial-state prior, Gaussian observation noise, observed
+data, matrix-valued `A`, `B`, and `C`, and leaves `noise = nothing`. Otherwise it uses
+[`DirectIteration`](@ref). Pass an algorithm explicitly to override this selection.
+
+# Arguments
+
+  - `prob`: State-space problem to solve.
+
+# Keyword Arguments
+
+All keyword arguments are forwarded to the selected solver. In particular,
+`save_everystep = false` stores only the initial and final states.
+
+# Examples
+
+```jldoctest
+julia> A = [0.95 0.1; 0.0 0.2];
+
+julia> B = [0.0; 0.01;;];
+
+julia> prob = LinearStateSpaceProblem(A, B, zeros(2), (0, 10));
+
+julia> sol = solve(prob);
+
+julia> length(sol.u)
+11
+```
+"""
 function CommonSolve.solve(prob::AbstractStateSpaceProblem; kwargs...)
     return CommonSolve.solve(
         prob,

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -46,10 +46,6 @@ run_qa(
             ),
         ),
     ),
-    api_docs_kwargs = (;
-        rendered = true,
-        rendered_ignore = (:remake, :solve),
-    ),
 )
 
 # JET cases tied to issue #187 are bespoke `report_call`s on specific solve paths:

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -5,7 +5,6 @@ using LinearAlgebra
 run_qa(
     DifferenceEquations;
     JET = nothing,            # JET is run below as bespoke report_call cases (issue #187), not package-wide
-    explicit_imports = true,
     ei_kwargs = (;
         # Names re-exported by a dependency rather than imported from their owner.
         all_explicit_imports_via_owners = (;


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

Removes the repository-specific rendered-docs override and declares the public `solve` and `remake` re-exports in the existing solver reference.