### PR TITLE
Bump DifferenceEquations to v1.1.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DifferenceEquations"
 uuid = "e0ca9c66-1f9e-11ec-127a-1304ce62169c"
-version = "1.1.2"
+version = "1.1.3"
 authors = ["various contributors"]
 
 [workspace]


### PR DESCRIPTION
Bumps `DifferenceEquations` **v1.1.2 → v1.1.3** (patch) so the accumulated unreleased `src/` changes on `main` can be registered.

**Rationale:** Update QA to SciMLTesting 2.4 (#200) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)