### PR TITLE
fix: honor state-space u0 overrides

### DIFF
--- a/src/problems/state_space_problems.jl
+++ b/src/problems/state_space_problems.jl
@@ -23,7 +23,7 @@ function DiffEqBase.get_concrete_problem(
     u0_promote = promote_u0(u0, p, tspan[1])
 
     if isconcreteu0(prob, tspan[1], kwargs) &&
-            typeof(u0_promote) === typeof(prob.u0) &&
+            u0_promote === prob.u0 &&
             p === prob.p &&
             return prob
     else

--- a/test/concretization.jl
+++ b/test/concretization.jl
@@ -1,0 +1,9 @@
+using DifferenceEquations, Test
+
+@testset "solve applies u0 override" begin
+    prob = LinearStateSpaceProblem([2.0;;], nothing, [1.0], (0, 2))
+
+    sol = solve(prob, DirectIteration(); u0 = [3.0])
+
+    @test sol.u == [[3.0], [6.0], [12.0]]
+end


### PR DESCRIPTION
Fixes https://github.com/SciML/DifferenceEquations.jl/issues/203.

`DiffEqBase.get_concrete_problem` retained the original problem whenever an overridden `u0` had the same type as `prob.u0`. It now retains it only when the effective initial state is the original value, so the generic `solve(prob, alg; u0 = ...)` path remakes and solves the overridden problem.

Ignore until reviewed by @ChrisRackauckas.

## Verification

Before this change:

```
/home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. test/concretization.jl
```

failed with:

```
Evaluated: [[1.0], [2.0], [4.0]] == [[3.0], [6.0], [12.0]]
```

After this change, the same command passed: `1/1`.

Also passed:

```
/home/crackauc/.juliaup/bin/julia +1 --project=@runic -e 'using Runic; Runic.main(["--check", "--diff", "src/problems/state_space_problems.jl", "test/concretization.jl"])'
typos --format brief src/problems/state_space_problems.jl test/concretization.jl
GROUP=Core /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test(; coverage = false)'
GROUP=QA /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test(; coverage = false)'
```

Core passed all declared suites. QA passed `21` tests with the repository's `2` existing broken JET cases. Docs are unchanged, so no docs build was required.