### PR TITLE
docs: make project metadata lookup independent of eval CWD

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -123,8 +123,9 @@ Pkg.status(; mode = PKGMODE_MANIFEST) # hide
 ```@eval
 using TOML
 using Markdown
-version = TOML.parse(read("../../Project.toml", String))["version"]
-name = TOML.parse(read("../../Project.toml", String))["name"]
+project = TOML.parsefile(joinpath(dirname(Base.active_project()), "..", "Project.toml"))
+version = project["version"]
+name = project["name"]
 link_manifest = "https://github.com/SciML/" * name * ".jl/tree/gh-pages/v" * version *
                 "/assets/Manifest.toml"
 link_project = "https://github.com/SciML/" * name * ".jl/tree/gh-pages/v" * version *


### PR DESCRIPTION
Fixes https://github.com/SciML/DifferenceEquations.jl/issues/204.

The index page's `@eval` block read `../../Project.toml` relative to Documenter's evaluation directory. It now derives the package project from the active docs environment and parses it once, so the metadata links render independently of that CWD.

Verification:
- Before the change, the focused `makedocs` reproduction (with `source = "docs/src"`, `build = build`, `checkdocs = :exports`, and `linkcheck = false`) failed with `SystemError: opening file "../../Project.toml"` and `:eval_block`.
- After the change, the identical focused build printed `focused Documenter build passed`.
- `julia +release --startup-file=no --project=docs docs/make.jl` completed Documenter's build, cross-reference, checkdocs, render, inventory, and deployment-skip stages. Link checking remained enabled; the existing external `ColPrac` GitHub link returned HTTP 429 and was reported under the repository's existing `warnonly = [:missing_docs, :linkcheck]` configuration.
- `GROUP=QA julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test(; coverage = false)'`: `21` pass, `2` existing broken JET cases, exit status `0`.
- `typos --format brief docs/src/index.md`, `git diff --check`, and Runic exited cleanly.

No docs checks were disabled or weakened. Ignore until reviewed by @ChrisRackauckas.