### PR TITLE
Keep 32-bit CI lane hard-failing

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -28,7 +28,6 @@ arch = "x86"
 [AD]
 versions = ["1"]
 in_all = false
-continue_on_error = true
 
 [QA]
 versions = ["lts", "1"]


### PR DESCRIPTION
## Summary
- Remove `continue_on_error = true` from the x86 / 32-bit test-group lane
- Matches org policy from SciML/DASSL.jl#118: keep failures visible until fixed

## Test plan
- [ ] x86 lane still schedules
- [ ] Failures fail the workflow


Made with [Cursor](https://cursor.com)